### PR TITLE
Add testing/coverage prompt

### DIFF
--- a/Software Testing/README.md
+++ b/Software Testing/README.md
@@ -1,3 +1,4 @@
 | Activity Type                    | Description                                                                                                                 | Example in ShareGPT                            |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
 | Bootstrap testing code           | Ask the students to generate testing code for a method. Then ask GenAI to do the same. Compare both solutions.               | [xZzqsqd](https://sharegpt.com/c/xZzqsqd)       |
+| Coverage           | Ask ChatGPT to show code and associated tests with different levels of coverage (0%, 25%, 75%, 100%). Then ask students to do the same with their own code               | [YOM9Ygf](https://sharegpt.com/c/YOM9Ygf)       |


### PR DESCRIPTION
Ask ChatGPT to show code and associated tests with different levels of coverage (0%, 25%, 75%, 100%). Then ask students to do the same with their own code